### PR TITLE
Pass the mp4boxfile object to extract metadata

### DIFF
--- a/mod.js
+++ b/mod.js
@@ -101,7 +101,7 @@ class MP4Demuxer {
       codedHeight: track.video.height,
       codedWidth: track.video.width,
       description: this.#description(track),
-      mp4boxfile: this.#file,
+      mp4boxFile: this.#file,
     });
 
     // Start demuxing.

--- a/mod.js
+++ b/mod.js
@@ -102,6 +102,7 @@ class MP4Demuxer {
       codedWidth: track.video.width,
       description: this.#description(track),
       mp4boxFile: this.#file,
+      info: info,
     });
 
     // Start demuxing.

--- a/mod.js
+++ b/mod.js
@@ -101,6 +101,7 @@ class MP4Demuxer {
       codedHeight: track.video.height,
       codedWidth: track.video.width,
       description: this.#description(track),
+      mp4boxfile: this.#file,
     });
 
     // Start demuxing.


### PR DESCRIPTION
It is sometimes helpful to have access to the mp4boxfile in order to do more advanced operations (in my case I wanted to read the comment of the video).